### PR TITLE
[chore] OCI 배포용 서버 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,29 +14,36 @@ jobs:
           host: ${{ secrets.OCI_HOST }}
           username: ${{ secrets.OCI_USERNAME }}
           key: ${{ secrets.OCI_KEY }}
-          timeout: 120s # Blue/Green 헬스체크 대기 시간 고려
+          timeout: 180s # 헬스체크 대기 시간 고려하여 넉넉히
           script: |
-            # 1. 정보 받기 & 검증
+            # 1. 입력값 검증 (커맨드 인젝션 방지)
             SERVICE_NAME="${{ github.event.client_payload.service_name }}"
             IMAGE_URL="${{ github.event.client_payload.image_url }}"
             IMAGE_TAG="${{ github.event.client_payload.image_tag }}"
             
-            if [ -z "$SERVICE_NAME" ]; then
-              echo "❌ Error: Service Name is missing!"
+            # 알파벳, 숫자, 하이픈, 언더바만 허용 (특수문자 차단)
+            if [[ ! "$SERVICE_NAME" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+              echo "❌ Error: Invalid Service Name"
               exit 1
             fi
             
+            if [[ ! "$IMAGE_TAG" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+               echo "❌ Error: Invalid Image Tag"
+               exit 1
+            fi
+
             echo "🚀 Start Deploy: $SERVICE_NAME ($IMAGE_URL:$IMAGE_TAG)"
             
-            mkdir -p ~/app && cd ~/app
+            # 작업 디렉토리 및 Nginx 설정 폴더 생성 (누락 방지)
+            mkdir -p ~/app/nginx/conf.d && cd ~/app
             
-            # 2. docker-compose.yml 생성 (Gateway Blue/Green + Nginx 포함)
-            # 매번 최신 구조로 덮어씌움
+            # 2. docker-compose.yml 생성
+            # 주의: 이미지 태그 자리에 변수(${TAG})를 넣어두고 나중에 sed로 교체합니다.
             cat <<EOF > docker-compose.yml
             version: '3.8'
             
             services:
-              # [0] Nginx (로드밸런서 & Blue/Green 스위처)
+              # [0] Nginx
               nginx:
                 image: nginx:latest
                 container_name: nginx
@@ -50,7 +57,7 @@ jobs:
 
               # [1] Gateway - Blue
               gateway-blue:
-                image: ghcr.io/final-project-gilmok/gateway-repo:latest
+                image: ghcr.io/final-project-gilmok/gateway-repo:\${GATEWAY_TAG:-latest}
                 container_name: gateway-blue
                 environment:
                   - SERVER_PORT=8080
@@ -59,10 +66,15 @@ jobs:
                   - AUTH_SERVER_URL=http://auth-server:9000
                 networks:
                   - msa-network
+                healthcheck:
+                  test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+                  interval: 10s
+                  timeout: 5s
+                  retries: 3
 
               # [1] Gateway - Green
               gateway-green:
-                image: ghcr.io/final-project-gilmok/gateway-repo:latest
+                image: ghcr.io/final-project-gilmok/gateway-repo:\${GATEWAY_TAG:-latest}
                 container_name: gateway-green
                 environment:
                   - SERVER_PORT=8080
@@ -71,13 +83,18 @@ jobs:
                   - AUTH_SERVER_URL=http://auth-server:9000
                 networks:
                   - msa-network
+                healthcheck:
+                  test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+                  interval: 10s
+                  timeout: 5s
+                  retries: 3
 
-              # [2] API 서버 (비즈니스 로직)
+              # [2] API 서버
               api-server:
-                image: ghcr.io/final-project-gilmok/api-repo:latest
+                image: ghcr.io/final-project-gilmok/api-repo:latest # (필요시 여기도 변수 처리 가능)
                 container_name: api-server
                 expose:
-                  - "8080"
+                  - "8080" # 외부 노출 X, 내부 통신만
                 restart: always
                 environment:
                   - TZ=Asia/Seoul
@@ -85,12 +102,12 @@ jobs:
                 networks:
                   - msa-network
 
-              # [3] 인증 서버 (Auth)
+              # [3] 인증 서버
               auth-server:
                 image: ghcr.io/final-project-gilmok/auth-repo:latest
                 container_name: auth-server
-                ports:
-                  - "9000:9000"
+                expose:
+                  - "9000" # 외부 노출 X
                 restart: always
                 environment:
                   - TZ=Asia/Seoul
@@ -98,21 +115,22 @@ jobs:
                 networks:
                   - msa-network
 
-              # [4] Redis (대기열용)
+              # [4] Redis (보안 강화: 외부 포트 제거)
               redis:
                 image: redis:alpine
                 container_name: redis-server
-                ports:
-                  - "6379:6379"
+                expose:
+                  - "6379" # 외부 접속 차단, 내부에서만 접속
+                # command: redis-server --requirepass ${{ secrets.REDIS_PASSWORD }} # (비번 설정 시 주석 해제)
                 networks:
                   - msa-network
 
-              # [5] MySQL (메인 DB)
+              # [5] MySQL (보안 강화: 외부 포트 제거)
               mysql:
                 image: mysql:8.0
                 container_name: mysql-server
-                ports:
-                  - "3306:3306"
+                expose:
+                  - "3306" # 외부 접속 차단
                 environment:
                   MYSQL_ROOT_PASSWORD: ${{ secrets.DB_ROOT_PASSWORD }}
                   MYSQL_DATABASE: gilmok_db
@@ -138,6 +156,14 @@ jobs:
               msa-network:
                 driver: bridge
             EOF
+
+            # [중요] 동적 태그 적용 (.env 파일 생성)
+            # Gateway 배포일 때만 해당 태그를 적용하고, 아니면 latest 유지
+            if [[ "$SERVICE_NAME" == "gateway-server" ]]; then
+                echo "GATEWAY_TAG=$IMAGE_TAG" > .env
+            else
+                echo "GATEWAY_TAG=latest" > .env
+            fi
             
             # 명령어 호환성 처리
             if command -v docker-compose &> /dev/null; then
@@ -146,12 +172,11 @@ jobs:
                 DOCKER_COMPOSE="docker compose"
             fi
 
-            # 3. 배포 로직 분기 (Gateway vs Others)
+            # 3. 배포 로직 분기
             if [[ "$SERVICE_NAME" == "gateway-server" ]]; then
                 echo "🔵 Gateway Service Detected -> Starting Blue/Green Deployment..."
             
-                # (1) 현재 실행 중인 컨테이너 확인 (Blue가 켜져 있으면 Green 배포, 반대면 Blue 배포)
-                CURRENT_COLOR="blue"
+                # (1) 현재 활성 컬러 확인
                 if [ $(sudo docker ps --format '{{.Names}}' | grep -w "gateway-blue") ]; then
                     CURRENT_COLOR="blue"
                     TARGET_COLOR="green"
@@ -159,26 +184,31 @@ jobs:
                     CURRENT_COLOR="green"
                     TARGET_COLOR="blue"
                 fi
+                echo "Current: $CURRENT_COLOR / Target: $TARGET_COLOR"
             
-                echo "Current Active: $CURRENT_COLOR / Target to Deploy: $TARGET_COLOR"
-            
-                # (2) 새 버전 이미지 Pull & Target 컨테이너 시작
+                # (2) Target 배포 시작
                 sudo $DOCKER_COMPOSE pull gateway-$TARGET_COLOR
                 sudo $DOCKER_COMPOSE up -d gateway-$TARGET_COLOR
             
-                # (3) Health Check (간단히 10초 대기, 실제론 curl로 200 OK 확인 권장)
+                # (3) Real Health Check (최대 60초 대기)
                 echo "Waiting for Health Check..."
-                sleep 15
+                for i in {1..12}; do
+                    response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/actuator/health || echo "fail")
+                    if [ "$response" == "200" ]; then
+                        echo "✅ Health Check Passed!"
+                        break
+                    fi
+                    if [ "$i" == "12" ]; then
+                        echo "❌ Health Check Failed! Aborting..."
+                        sudo $DOCKER_COMPOSE stop gateway-$TARGET_COLOR
+                        exit 1
+                    fi
+                    echo "Checking... ($i/12)"
+                    sleep 5
+                done
             
-                # (4) Nginx 설정 변경 (동적 Reload)
-                # 여기선 간단히 Nginx 컨테이너 재시작으로 처리하거나, 
-                # 미리 준비된 nginx.conf 템플릿을 교체하고 reload 하는 방식 사용
-                # MVP 단계에선 가장 쉬운 방법: Target만 남기고 다 끄면 Nginx가 알아서 붙음 (단, Nginx 설정이 upstream 잡혀있어야 함)
-                # 정석: Nginx 설정 파일 sed로 수정 후 reload
-            
+                # (4) Nginx 트래픽 전환 (Reload 사용)
                 echo "Switching Traffic to $TARGET_COLOR..."
-            
-                # Nginx 설정 파일 생성 (Target을 가리키도록)
                 cat <<NGINX_CONF > ./nginx/conf.d/default.conf
                 upstream gateway_backend {
                     server gateway-$TARGET_COLOR:8080;
@@ -189,21 +219,27 @@ jobs:
                         proxy_pass http://gateway_backend;
                         proxy_set_header Host \$host;
                         proxy_set_header X-Real-IP \$remote_addr;
+                        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
                     }
                 }
                 NGINX_CONF
             
-                # Nginx 설정 적용
-                sudo $DOCKER_COMPOSE restart nginx
+                # 설정 적용 (무중단 Reload)
+                # 컨테이너가 꺼져있으면 start, 켜져있으면 reload
+                if [ $(sudo docker ps -q -f name=nginx) ]; then
+                    sudo docker exec nginx nginx -s reload
+                else
+                    sudo $DOCKER_COMPOSE up -d nginx
+                fi
             
-                # (5) 이전 버전(Current) 중지
+                # (5) 이전 버전 중지
                 echo "Stopping Old Version ($CURRENT_COLOR)..."
                 sudo $DOCKER_COMPOSE stop gateway-$CURRENT_COLOR
             
-                echo "✅ Gateway Blue/Green Deployment Complete!"
-            
             else
-                # 4. 일반 서비스 배포 (API, Auth 등)
+                # 4. 일반 서비스 배포
+                # 일반 서비스도 태그를 반영하려면 여기서 sed로 docker-compose.yml을 수정하거나 
+                # .env 방식을 확장해야 함 (MVP 단계라 latest 사용 유지 시 이대로 진행)
                 echo "🟢 Standard Deployment for $SERVICE_NAME..."
                 sudo $DOCKER_COMPOSE pull $SERVICE_NAME
                 sudo $DOCKER_COMPOSE up -d $SERVICE_NAME --remove-orphans


### PR DESCRIPTION
## 🔍 What
- 배포용 레포를 OCI로 배포하도록 Git Actions 설정 추가


## 🧪 How to test
- deploy.yml이 모든 서비스를 포함하고 있는지
- 오타는 없는지 확인
- 블루 그린 배포가 적용되어있는지 수정

## 🔗 Issue
- Closes: #1

---
### ✅ 체크리스트
- [ ] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * OCI 대상 원격 호스트로 배포를 자동화하는 워크플로우 추가
  * 여러 마이크로서비스 동시 배포 지원(게이트웨이, API, 인증, DB, 캐시 등)
  * 게이트웨이에 대한 Blue/Green 무중단 전환 및 트래픽 전환 자동화
  * 원격 환경 검증(헬스체크) 및 구성 업데이트·재시작 처리
  * 환경 변수 기반 태그 설정 및 사용하지 않는 이미지 자동 정리 기능 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->