### PR TITLE
[fix] 백엔드와 프론트엔드 경로 중복에 대한 문제

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,15 +125,14 @@ jobs:
                 printf '    proxy_set_header X-Real-IP $remote_addr;\n'
                 printf '    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n'
                 printf '  }\n\n'
-
-                for path in admin users auth events queue reservations; do
-                  printf '  location ~ ^/%s(/|$) {\n' "$path"
-                  printf '    proxy_pass http://gateway_backend;\n'
-                  printf '    proxy_set_header Host $host;\n'
-                  printf '    proxy_set_header X-Real-IP $remote_addr;\n'
-                  printf '    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n'
-                  printf '  }\n\n'
-                done
+            
+                printf '  location ~ ^/api/(admin|users|auth|events|queue|reservations)(/|$) {\n'
+                printf '    rewrite ^/api/(.*)$ /$1 break;\n'
+                printf '    proxy_pass http://gateway_backend;\n'
+                printf '    proxy_set_header Host $host;\n'
+                printf '    proxy_set_header X-Real-IP $remote_addr;\n'
+                printf '    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n'
+                printf '  }\n\n'
 
                 printf '  location ~ ^/actuator(/|$) {\n'
                 printf '    allow 127.0.0.1;\n'


### PR DESCRIPTION
#31

## 🔍 What
- nginx 설정을 통해 `/api`를 붙여 백엔드 api 호출임을 명시

## 🔗 Issue
- Closes: #31 
- Refs: #31 

---
### ✅ 체크리스트
- [x] base가 **main**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 구성 최적화를 통해 API 라우팅 설정을 간소화했습니다.

**참고**: 이번 변경사항은 내부 인프라 업데이트로, 사용자에게 직접적인 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->