### PR TITLE
[chore] Nginx Upstream DNS 지연 파싱 적용 및 동시 배포 대기열 타임아웃 연장

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,7 @@ jobs:
             }
 
             is_nginx_running() {
-              [ "$(sudo docker ps --filter name=^nginx$ --format '{{.Names}}')" = "nginx" ]
+              [ "$(sudo docker ps -f name=^nginx$ -f status=running --format '{{.Names}}')" = "nginx" ]
             }
 
             start_and_verify_nginx() {
@@ -139,6 +139,7 @@ jobs:
                 printf '}\n\n'
                 printf 'server {\n'
                 printf '  listen 80;\n\n'
+                printf '  resolver 127.0.0.11 valid=10s;\n\n'
 
                 printf '  location /grafana {\n'
                 printf '    return 301 /grafana/;\n'
@@ -154,7 +155,8 @@ jobs:
                 printf '  }\n\n'
 
                 printf '  location / {\n'
-                printf '    proxy_pass http://frontend:8080;\n'
+                printf '    set $frontend_upstream http://frontend:8080;\n'
+                printf '    proxy_pass $frontend_upstream;\n'
                 printf '    proxy_set_header Host $host;\n'
                 printf '    proxy_set_header X-Real-IP $remote_addr;\n'
                 printf '    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n'
@@ -421,12 +423,22 @@ jobs:
               render_nginx_conf "gateway-$TARGET_COLOR"
 
               if is_nginx_running; then
-                if ! sudo docker exec nginx nginx -t; then
-                  echo "⬅️ Nginx config test failed. Rolling back..."
-                  cp ./nginx/conf.d/default.conf.bak ./nginx/conf.d/default.conf
-                  exit 1
+                if ! NGINX_TEST_OUT=$(sudo docker exec nginx nginx -t 2>&1); then
+                  if echo "$NGINX_TEST_OUT" | grep -qi "restarting"; then
+                    echo "⚠️ Nginx is in a restart loop. Forcing recreate..."
+                    if ! start_and_verify_nginx; then
+                      cp ./nginx/conf.d/default.conf.bak ./nginx/conf.d/default.conf
+                      exit 1
+                    fi
+                  else
+                    echo "$NGINX_TEST_OUT"
+                    echo "⬅️ Nginx config test failed. Rolling back..."
+                    cp ./nginx/conf.d/default.conf.bak ./nginx/conf.d/default.conf
+                    exit 1
+                  fi
+                else
+                  sudo docker exec nginx nginx -s reload
                 fi
-                sudo docker exec nginx nginx -s reload
               else
                 if ! start_and_verify_nginx; then
                   cp ./nginx/conf.d/default.conf.bak ./nginx/conf.d/default.conf


### PR DESCRIPTION
#50

## 🔍 What
- 동시 배포 서버 다운 방지 및 대기열 타임아웃 연장

## 🔗 Issue
- Closes: #50 
- Refs: #50 

---
### ✅ 체크리스트
- [x] base가 **main**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [ ] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Nginx 컨테이너 상태 확인 프로세스 개선으로 배포 안정성 강화
  * 배포 중 Nginx 재시작 오류 시 자동 복구 메커니즘 추가
  * 게이트웨이 블루/그린 배포 프로세스 최적화로 재시작 실패 시 빠른 롤백 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->